### PR TITLE
Correct board ID for Zero in Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 script:
   - arduino --verify --board arduino:avr:uno $PWD/examples/FreeMemory/FreeMemory.ino
   - arduino --verify --board arduino:sam:arduino_due_x $PWD/examples/FreeMemory/FreeMemory.ino
-  - arduino --verify --board arduino:samd:zero $PWD/examples/FreeMemory/FreeMemory.ino
+  - arduino --verify --board arduino:samd:arduino_zero_edbg $PWD/examples/FreeMemory/FreeMemory.ino
   - arduino --verify --board esp8266:esp8266:huzzah $PWD/examples/FreeMemory/FreeMemory.ino
   - arduino --verify --board arduino:avr:leonardo $PWD/examples/FreeMemory/FreeMemory.ino
   - arduino --verify --board adafruit:avr:trinket5 $PWD/examples/FreeMemory/FreeMemory.ino


### PR DESCRIPTION
Incorrect FQBN causes the Arduino IDE to attempt to start the GUI, which results in a hang and eventual timeout on the headless Travis CI machine.

Reference: https://github.com/arduino/ArduinoCore-samd/blob/1.8.7/boards.txt#L19

The CI build will still fail, but at least now it's failing due to incompatibilities between the code and the board, rather than due to an invalid Travis CI configuration.